### PR TITLE
Refactor portal context service to use `PortalContext` interface and support dynamic API URL placeholders

### DIFF
--- a/src/portal-options/models/luigi-context.ts
+++ b/src/portal-options/models/luigi-context.ts
@@ -1,0 +1,4 @@
+export interface PortalContext extends Record<string, any> {
+  crdGatewayApiUrl?: string;
+  iamServiceApiUrl?: string;
+}

--- a/src/portal-options/pm-portal-context.service.spec.ts
+++ b/src/portal-options/pm-portal-context.service.spec.ts
@@ -138,6 +138,25 @@ describe('PMPortalContextService', () => {
     }
   });
 
+  it('should process GraphQL IAM API URL with subdomain', async () => {
+    process.env.OPENMFP_PORTAL_CONTEXT_IAM_SERVICE_API_URL =
+      'https://${org-subdomain}example.com/iam/graphql';
+
+    try {
+      mockedGetDomainAndOrganization.mockReturnValue('test-org');
+
+      mockRequest.hostname = 'example.com';
+
+      const result = await service.getContextValues(mockRequest as Request);
+
+      expect(result.iamServiceApiUrl).toBe(
+        'https://test-org.example.com/iam/graphql',
+      );
+    } finally {
+      delete process.env.OPENMFP_PORTAL_CONTEXT_IAM_SERVICE_API_URL;
+    }
+  });
+
   it('should process GraphQL gateway API URL without subdomain when hostname matches domain', async () => {
     process.env.OPENMFP_PORTAL_CONTEXT_CRD_GATEWAY_API_URL =
       'https://${org-subdomain}api.example.com/${org-name}/graphql';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for IAM service API URL processing with subdomain resolution.

* **Refactor**
  * Improved internal type definitions and URL processing for portal context configuration, enhancing type safety and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->