### PR TITLE
chore: add publishConfig to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.5.37",
   "author": "Platform Mesh",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "url": "git+https://github.com/platform-mesh/portal-server-lib.git"
   },


### PR DESCRIPTION
## Summary
- Add `publishConfig` field with `"access": "public"` to package.json

## Purpose
This change enables the organization-wide Renovate configuration to properly detect this repository as a publishable library rather than an application.

## Impact
With this change, Renovate will:
- Convert exact dependency versions to ranges (e.g., `1.2.3` → `^1.2.3`) when updating
- Allow library consumers to automatically receive compatible updates
- Apply the appropriate `replace` range strategy for library dependencies

## Related Changes
This is part of a coordinated update to improve dependency management across the platform-mesh organization:
- Similar PR created for `portal-ui-lib` (#176)
- Organization Renovate config updated to use `publishConfig` for library detection