### PR TITLE
fix: gracefully handle ContentConfigurations without configurationResult

### DIFF
--- a/src/portal-options/service-providers/content-configuration-service-providers.service.spec.ts
+++ b/src/portal-options/service-providers/content-configuration-service-providers.service.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { RequestContext } from '../pm-request-context-provider.js';
 import { ContentConfigurationServiceProvidersService } from './content-configuration-service-providers.service.js';
 import { welcomeNodeConfig } from './models/welcome-node-config.js';
@@ -13,6 +14,10 @@ jest.mock('graphql-request', () => {
     },
   };
 });
+
+// Mock the Logger to capture warnings
+const mockLoggerWarn = jest.fn();
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(mockLoggerWarn);
 
 describe('ContentConfigurationServiceProvidersService', () => {
   let service: ContentConfigurationServiceProvidersService;
@@ -30,6 +35,7 @@ describe('ContentConfigurationServiceProvidersService', () => {
         'http://example.com/kubernetes-graphql-gateway/root/graphql',
       account: 'acc1',
     } as RequestContext;
+    mockLoggerWarn.mockClear();
   });
 
   it('throws if token is missing', async () => {
@@ -127,7 +133,7 @@ describe('ContentConfigurationServiceProvidersService', () => {
     );
   });
 
-  it('throws on missing configurationResult', async () => {
+  it('skips items with missing configurationResult and logs warning', async () => {
     mockClient.request.mockResolvedValue({
       ui_platform_mesh_io: {
         v1alpha1: {
@@ -146,9 +152,112 @@ describe('ContentConfigurationServiceProvidersService', () => {
         },
       },
     });
-    await expect(
-      service.getServiceProviders('token', ['entity'], context),
-    ).rejects.toThrow('Missing configurationResult');
+    const result = await service.getServiceProviders(
+      'token',
+      ['entity'],
+      context,
+    );
+
+    // Should return empty content configurations (item was skipped)
+    expect(result.rawServiceProviders[0].contentConfiguration).toHaveLength(0);
+
+    // Should log a warning about the skipped item
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining("Skipping ContentConfiguration 'conf1'"),
+    );
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('missing configurationResult'),
+    );
+  });
+
+  it('skips items with invalid JSON in configurationResult and logs warning', async () => {
+    mockClient.request.mockResolvedValue({
+      ui_platform_mesh_io: {
+        v1alpha1: {
+          ContentConfigurations: {
+            items: [
+              {
+                metadata: {
+                  name: 'invalid-json',
+                  labels: { 'ui.platform-mesh.io/entity': 'entity' },
+                },
+                spec: { remoteConfiguration: { url: 'http://remote' } },
+                status: { configurationResult: 'not valid json {' },
+              },
+            ],
+          },
+        },
+      },
+    });
+    const result = await service.getServiceProviders(
+      'token',
+      ['entity'],
+      context,
+    );
+
+    // Should return empty content configurations (item was skipped)
+    expect(result.rawServiceProviders[0].contentConfiguration).toHaveLength(0);
+
+    // Should log a warning about the skipped item
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining("Skipping ContentConfiguration 'invalid-json'"),
+    );
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('failed to parse configurationResult'),
+    );
+  });
+
+  it('processes valid items while skipping invalid ones', async () => {
+    mockClient.request.mockResolvedValue({
+      ui_platform_mesh_io: {
+        v1alpha1: {
+          ContentConfigurations: {
+            items: [
+              {
+                metadata: {
+                  name: 'valid-config',
+                  labels: { 'ui.platform-mesh.io/entity': 'entity' },
+                },
+                spec: { remoteConfiguration: { url: 'http://remote' } },
+                status: {
+                  configurationResult: JSON.stringify({ url: 'http://valid' }),
+                },
+              },
+              {
+                metadata: {
+                  name: 'missing-result',
+                  labels: { 'ui.platform-mesh.io/entity': 'entity' },
+                },
+                spec: { remoteConfiguration: { url: 'http://remote' } },
+                status: {},
+              },
+              {
+                metadata: {
+                  name: 'invalid-json',
+                  labels: { 'ui.platform-mesh.io/entity': 'entity' },
+                },
+                spec: { remoteConfiguration: { url: 'http://remote' } },
+                status: { configurationResult: 'not json' },
+              },
+            ],
+          },
+        },
+      },
+    });
+    const result = await service.getServiceProviders(
+      'token',
+      ['entity'],
+      context,
+    );
+
+    // Should only return the valid configuration
+    expect(result.rawServiceProviders[0].contentConfiguration).toHaveLength(1);
+    expect(result.rawServiceProviders[0].contentConfiguration[0].url).toBe(
+      'http://valid',
+    );
+
+    // Should log warnings for both skipped items
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(2);
   });
 
   it('throws if response structure is invalid', async () => {

--- a/src/portal-options/service-providers/content-configuration-service-providers.service.ts
+++ b/src/portal-options/service-providers/content-configuration-service-providers.service.ts
@@ -3,7 +3,7 @@ import { processContentConfigurationForAccountHierarchy } from '../utils/account
 import { contentConfigurationsQuery } from './contentconfigurations-query.js';
 import { ContentConfigurationQueryResponse } from './models/contentconfigurations.js';
 import { welcomeNodeConfig } from './models/welcome-node-config.js';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import {
   ContentConfiguration,
   ServiceProviderResponse,
@@ -13,6 +13,9 @@ import { GraphQLClient } from 'graphql-request';
 
 @Injectable()
 export class ContentConfigurationServiceProvidersService implements ServiceProviderService {
+  private readonly logger = new Logger(
+    ContentConfigurationServiceProvidersService.name,
+  );
   async getServiceProviders(
     token: string,
     entities: string[],
@@ -71,11 +74,16 @@ export class ContentConfigurationServiceProvidersService implements ServiceProvi
           )
           .map((item) => {
             try {
-              // Validate required fields
+              // Skip items without configurationResult (not ready yet)
+              // This can happen when the ContentConfiguration resource exists but
+              // the remote configuration hasn't been fetched yet (e.g., DNS failure,
+              // network issues, or the remote server is unavailable)
               if (!item.status?.configurationResult) {
-                throw new Error(
-                  `Missing configurationResult for item: ${item.metadata?.name || 'unknown'}`,
+                this.logger.warn(
+                  `Skipping ContentConfiguration '${item.metadata?.name || 'unknown'}': ` +
+                    `missing configurationResult (resource may not be ready)`,
                 );
+                return null;
               }
 
               const contentConfiguration = JSON.parse(
@@ -98,23 +106,17 @@ export class ContentConfigurationServiceProvidersService implements ServiceProvi
               return contentConfiguration;
             } catch (parseError) {
               // Log the error but don't fail the entire operation
-              console.error(
-                `Failed to parse configuration for item ${item.metadata?.name || 'unknown'}:`,
-                parseError,
+              // Skip items with invalid JSON in configurationResult
+              this.logger.warn(
+                `Skipping ContentConfiguration '${item.metadata?.name || 'unknown'}': ` +
+                  `failed to parse configurationResult - ${parseError instanceof Error ? parseError.message : 'unknown error'}`,
               );
-
-              // Re-throw specific errors as-is, others as JSON parse errors
-              if (
-                parseError instanceof Error &&
-                parseError.message.includes('Missing configurationResult')
-              ) {
-                throw parseError;
-              }
-              throw new Error(
-                `Invalid JSON in configurationResult for item: ${item.metadata?.name || 'unknown'}`,
-              );
+              return null;
             }
-          });
+          })
+          .filter(
+            (config): config is ContentConfiguration => config !== null,
+          );
 
       return {
         rawServiceProviders: [
@@ -127,13 +129,6 @@ export class ContentConfigurationServiceProvidersService implements ServiceProvi
         ],
       };
     } catch (error) {
-      // Re-throw with more context if it's not already our custom error
-      if (
-        error instanceof Error &&
-        error.message.includes('configurationResult')
-      ) {
-        throw error;
-      }
       throw new Error(
         `Failed to fetch content configurations: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );


### PR DESCRIPTION
## Summary

- Skip ContentConfigurations that don't have a `configurationResult` populated instead of throwing an error
- Skip ContentConfigurations with invalid JSON in `configurationResult`
- Log warnings for skipped items so operators can identify misconfigured resources
- Continue processing other valid ContentConfigurations

## Problem

Previously, the portal would throw a 500 Internal Server Error when loading workspaces that had APIBindings to providers with broken ContentConfiguration resources (e.g., DNS resolution failures, network issues, or remote server unavailable).

For example, if a `metal-ui` ContentConfiguration had a DNS resolution failure:
```
dial tcp: lookup metal-api-msp03.dev.showroom.apeirora.eu: no such host
```

The entire workspace would fail to load with:
```
Error: Missing configurationResult for item: metal-ui
```

## Solution

Instead of throwing an error for individual broken ContentConfigurations, we now:
1. Skip the broken item
2. Log a warning with the item name and reason
3. Continue processing other valid ContentConfigurations

This ensures that a single broken ContentConfiguration from one provider doesn't prevent the entire workspace from loading.

## Test plan

- [x] Unit tests updated to verify new behavior
- [x] All existing tests pass
- [x] Manual testing on cc-d2 with the dominik workspace