### PR TITLE
feat: replace suffixes with prefixes

### DIFF
--- a/src/portal-options/service-providers/content-configuration-service-providers.service.spec.ts
+++ b/src/portal-options/service-providers/content-configuration-service-providers.service.spec.ts
@@ -309,7 +309,7 @@ describe('ContentConfigurationServiceProvidersService', () => {
         .data.nodes[0].children[0];
 
     expect(childNode.defineEntity.id).toBe('old-id');
-    expect(childNode.pathSegment).toBe(':core_platform-mesh_io_accountId:2');
+    expect(childNode.pathSegment).toBe(':2_core_platform-mesh_io_accountId');
   });
 
   it('does not apply processContentConfigurationForAccountHierarchy when accountPath is not provided', async () => {

--- a/src/portal-options/service-providers/kubernetes-service-providers.service.spec.ts
+++ b/src/portal-options/service-providers/kubernetes-service-providers.service.spec.ts
@@ -536,7 +536,7 @@ describe('KubernetesServiceProvidersService', () => {
         .data.nodes[0].children[0];
 
     expect(childNode.defineEntity.id).toBe('old-id');
-    expect(childNode.pathSegment).toBe(':core_platform-mesh_io_accountId:2');
+    expect(childNode.pathSegment).toBe(':2_core_platform-mesh_io_accountId');
   });
 
   it('should not apply processContentConfigurationForAccountHierarchy when accountPath is not provided', async () => {

--- a/src/portal-options/utils/account-hierarchy-resolver.spec.ts
+++ b/src/portal-options/utils/account-hierarchy-resolver.spec.ts
@@ -129,7 +129,7 @@ describe('updateAccountNodeChildren', () => {
       .children?.[0] as any;
 
     expect(childNode.defineEntity.id).toBe('old-id');
-    expect(childNode.pathSegment).toBe(':core_platform-mesh_io_accountId:2');
+    expect(childNode.pathSegment).toBe(':2_core_platform-mesh_io_accountId');
   });
 
   it('should replace all additional fields equal to previous pathSegment', () => {
@@ -167,18 +167,18 @@ describe('updateAccountNodeChildren', () => {
     const childNode = result.luigiConfigFragment.data.nodes[0]
       .children?.[0] as any;
 
-    expect(childNode.pathSegment).toBe(':core_platform-mesh_io_accountId:2');
+    expect(childNode.pathSegment).toBe(':2_core_platform-mesh_io_accountId');
     expect(childNode.defineEntity.contextKey).toBe(
-      ':core_platform-mesh_io_accountId:2',
+      ':2_core_platform-mesh_io_accountId',
     );
     expect(childNode.defineEntity.additionalContextKeys[0]).toBe(
-      ':core_platform-mesh_io_accountId:2',
+      ':2_core_platform-mesh_io_accountId',
     );
-    expect(childNode.context.customPath).toBe(':core_platform-mesh_io_accountId:2');
+    expect(childNode.context.customPath).toBe(':2_core_platform-mesh_io_accountId');
     expect(childNode.context.nested[0].deepPath).toBe(
-      ':core_platform-mesh_io_accountId:2',
+      ':2_core_platform-mesh_io_accountId',
     );
-    expect(childNode.navHeader.label).toBe(':core_platform-mesh_io_accountId:2');
+    expect(childNode.navHeader.label).toBe(':2_core_platform-mesh_io_accountId');
   });
 
   it('should keep defineEntity.id controlled only by explicit assignment', () => {
@@ -207,7 +207,7 @@ describe('updateAccountNodeChildren', () => {
     const childNode = result.luigiConfigFragment.data.nodes[0]
       .children?.[0] as any;
 
-    expect(childNode.defineEntity.id).toBe(':core_platform-mesh_io_accountId:2');
+    expect(childNode.defineEntity.id).toBe(':2_core_platform-mesh_io_accountId');
   });
 
   it('should not replace strings that only partially match previous pathSegment', () => {
@@ -237,7 +237,7 @@ describe('updateAccountNodeChildren', () => {
     const childNode = result.luigiConfigFragment.data.nodes[0]
       .children?.[0] as any;
 
-    expect(childNode.context.exact).toBe(':core_platform-mesh_io_accountId:2');
+    expect(childNode.context.exact).toBe(':2_core_platform-mesh_io_accountId');
     expect(childNode.context.partial).toBe(':core_platform-mesh_io_accountId:suffix');
   });
 
@@ -291,7 +291,7 @@ describe('updateAccountNodeChildren', () => {
       .children?.[0] as any;
 
     expect(childNode.defineEntity.id).toBe('old-id');
-    expect(childNode.pathSegment).toBe(':core_platform-mesh_io_accountId:4');
+    expect(childNode.pathSegment).toBe(':4_core_platform-mesh_io_accountId');
   });
 
   it('should not fail when there are no nodes', () => {

--- a/src/portal-options/utils/account-hierarchy-resolver.ts
+++ b/src/portal-options/utils/account-hierarchy-resolver.ts
@@ -38,7 +38,7 @@ export const updateAccountNodeChildren = (
     const nextHierarchyLevel =
       accountPath.split(':').filter(Boolean).length + 1;
     const previousPathSegment = accountChildrenNode.pathSegment;
-    const nextPathSegment = `:${ACCOUNT_ENTITY_TYPE}Id:${nextHierarchyLevel}`;
+    const nextPathSegment = `:${nextHierarchyLevel}_${ACCOUNT_ENTITY_TYPE}Id`;
 
     replaceStringDeep(
       accountChildrenNode,


### PR DESCRIPTION
Replace account level suffixes with prefixes, which is helps to remove acountLevel from cc files