### PR TITLE
chore: inline CI pipeline per ADR-004

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,0 +1,17 @@
+name: auto-labeler
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  auto-labeler:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    uses: platform-mesh/.github/.github/workflows/job-auto-labeler.yml@main

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -1,4 +1,5 @@
-name: pipe
+name: ci
+
 on:
   push:
     branches:
@@ -8,13 +9,52 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: write
+  id-token: write
+
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  pipe:
-    uses: platform-mesh/.github/.github/workflows/pipeline-node-module.yml@main
+  # ──────────────────────────────────────────────
+  # Always-run jobs (PR + main)
+  # ──────────────────────────────────────────────
+  build:
+    uses: platform-mesh/.github/.github/workflows/job-node-test.yml@main
+    secrets: inherit
+
+  # ──────────────────────────────────────────────
+  # Quality gate (aggregates required checks)
+  # ──────────────────────────────────────────────
+  quality-gate:
+    if: always()
+    permissions: {}
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.build.result }}" != "success" ]]; then
+            echo "build failed"
+            exit 1
+          fi
+
+  # ──────────────────────────────────────────────
+  # Release jobs (main branch only)
+  # ──────────────────────────────────────────────
+  create-version:
+    if: github.ref == 'refs/heads/main'
+    uses: platform-mesh/.github/.github/workflows/job-create-version.yml@main
+    secrets: inherit
+
+  publish:
+    if: github.ref == 'refs/heads/main'
+    needs: [create-version, build]
+    uses: platform-mesh/.github/.github/workflows/job-node-publish.yml@main
     secrets: inherit
     with:
+      version: ${{ needs.create-version.outputs.strictVersion }}
       environment: npmjs:@platform-mesh/portal-server-lib


### PR DESCRIPTION
## Summary

- Inlines the `pipeline-node-module.yml` shared workflow into the repository per [ADR-004](https://github.com/platform-mesh/architecture/blob/main/adr/004-shared-ci-workflow-strategy.md)
- Adds `quality-gate` job as aggregated required status check
- Adds `auto-labeler` workflow