### PR TITLE
fix: authenticate logout with HTTP Basic and send a usable end-session fallback

### DIFF
--- a/src/portal-options/logout-callback.service.spec.ts
+++ b/src/portal-options/logout-callback.service.spec.ts
@@ -63,8 +63,34 @@ describe('PMLogoutService', () => {
     expect(httpService.post).toHaveBeenCalledWith(
       'https://keycloak/logout',
       expect.any(URLSearchParams),
-      { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
+      {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        auth: { username: 'client-id', password: 'secret' },
+      },
     );
+  });
+
+  it('should not send the client secret as a form parameter', async () => {
+    const mockRequest = {} as Request;
+    const mockResponse = {} as Response;
+
+    (authConfigService.getAuthConfig as jest.Mock).mockResolvedValue({
+      clientId: 'client-id',
+      clientSecret: 'secret',
+      endSessionUrl: 'https://keycloak/logout',
+    });
+    (cookiesService.getAuthCookie as jest.Mock).mockReturnValue(
+      'refresh-token',
+    );
+    (httpService.post as jest.Mock).mockReturnValue(of({ data: {} }));
+
+    await service.handleLogout(mockRequest, mockResponse);
+
+    const body = (httpService.post as jest.Mock).mock
+      .calls[0][1] as URLSearchParams;
+    expect(body.get('refresh_token')).toBe('refresh-token');
+    expect(body.get('client_secret')).toBeNull();
+    expect(body.get('client_id')).toBeNull();
   });
 
   it('should return logoutWithIdToken URL when logout fails', async () => {
@@ -105,9 +131,39 @@ describe('PMLogoutService', () => {
     const result = (service as any).logoutWithIdToken(
       request,
       'https://kc/logout',
+      'client-id',
     );
     expect(result).toBe(
       'https://kc/logout?id_token_hint=token123&post_logout_redirect_uri=https%3A%2F%2Fexample.com',
     );
+  });
+
+  it('logoutWithIdToken should fall back to client_id when no id token is present', () => {
+    const request = {
+      query: { post_logout_redirect_uri: 'https://example.com' },
+    } as unknown as Request;
+
+    const result = (service as any).logoutWithIdToken(
+      request,
+      'https://kc/logout',
+      'client-id',
+    );
+
+    expect(result).toBe(
+      'https://kc/logout?client_id=client-id&post_logout_redirect_uri=https%3A%2F%2Fexample.com',
+    );
+    expect(result).not.toContain('id_token_hint');
+  });
+
+  it('logoutWithIdToken should omit an absent post logout redirect uri', () => {
+    const request = { query: {} } as unknown as Request;
+
+    const result = (service as any).logoutWithIdToken(
+      request,
+      'https://kc/logout',
+      'client-id',
+    );
+
+    expect(result).toBe('https://kc/logout?client_id=client-id');
   });
 });

--- a/src/portal-options/logout-callback.service.ts
+++ b/src/portal-options/logout-callback.service.ts
@@ -29,14 +29,20 @@ export class PMLogoutService implements LogoutCallback {
       const refreshToken = this.cookiesService.getAuthCookie(request);
 
       const body = new URLSearchParams({
-        client_id: authConfig.clientId,
-        client_secret: authConfig.clientSecret,
         refresh_token: refreshToken,
       });
 
+      // Client credentials go in the Authorization header, not the form body:
+      // the client is registered with token_endpoint_auth_method
+      // client_secret_basic, and an IdP that enforces it rejects credentials
+      // sent as form parameters with unauthorized_client.
       await firstValueFrom(
         this.httpService.post(authConfig.endSessionUrl, body, {
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          auth: {
+            username: authConfig.clientId,
+            password: authConfig.clientSecret,
+          },
         }),
       );
     } catch (error: any) {
@@ -45,16 +51,36 @@ export class PMLogoutService implements LogoutCallback {
         error?.response?.data || error.message,
       );
       this.logger.warn('Trying to log out with the id token');
-      return this.logoutWithIdToken(request, authConfig.endSessionUrl);
+      return this.logoutWithIdToken(
+        request,
+        authConfig.endSessionUrl,
+        authConfig.clientId,
+      );
     }
   }
 
-  private logoutWithIdToken(request: Request, endSessionUrl: string) {
+  private logoutWithIdToken(
+    request: Request,
+    endSessionUrl: string,
+    clientId: string,
+  ) {
     const { id_token_hint, post_logout_redirect_uri } = request.query;
-    const params = new URLSearchParams({
-      id_token_hint: String(id_token_hint || ''),
-      post_logout_redirect_uri: String(post_logout_redirect_uri || ''),
-    });
+    const params = new URLSearchParams();
+
+    // RP-initiated logout honours post_logout_redirect_uri only together with
+    // id_token_hint or client_id. An empty id_token_hint is not a no-op: the
+    // IdP rejects the request ("Missing parameters: id_token_hint") and the
+    // user is stranded on an error page instead of being signed out.
+    if (id_token_hint) {
+      params.set('id_token_hint', String(id_token_hint));
+    } else {
+      params.set('client_id', clientId);
+    }
+
+    if (post_logout_redirect_uri) {
+      params.set('post_logout_redirect_uri', String(post_logout_redirect_uri));
+    }
+
     return `${endSessionUrl}?${params}`;
   }
 }


### PR DESCRIPTION
## Problem

Keycloak 26.x enforces the client's registered `token_endpoint_auth_method` via the `client.secret.authentication.allowed.method` attribute, and the security-operator registers portal clients with `client_secret_basic`. `PMLogoutService` sends the client secret in the POST body (`client_secret_post`), so the back-channel logout fails with `unauthorized_client` ("Client requires method 'client_secret_basic'"). The code then falls back to a front-channel end-session redirect built with an **empty `id_token_hint`**, and Keycloak dead-ends the user on "We are sorry… Missing parameters: id_token_hint" instead of completing the logout.

Verified live against a Keycloak 26.6.1 installation: byte-identical logout call with the secret in the POST body → `unauthorized_client`; same call with HTTP Basic → passes client authentication.

## Change

- send the client credentials via HTTP Basic (axios `auth`) — the OIDC-recommended default that Keycloak accepts regardless of the registered method; the form body now carries only `refresh_token`
- the front-channel fallback builds a usable end-session URL: `id_token_hint` when one is present, otherwise `client_id`; `post_logout_redirect_uri` is omitted when absent instead of being sent empty

## Tests

6 specs in `logout-callback.service.spec.ts`, including a guard that the secret never appears in the form body and both fallback URL shapes. 4 of them fail on the unpatched code; full suite green (133).
